### PR TITLE
[~] include->include_tasks

### DIFF
--- a/roles/components/tasks/component.yml
+++ b/roles/components/tasks/component.yml
@@ -22,15 +22,15 @@
       vars:
         installObj: '{{ componentObj.install | default({}) }}'
       tags: install
-    - include: configs.yml
+    - include_tasks: configs.yml
       vars:
         configsObj: '{{ componentObj.configs | default({}) }}'
       tags: configs
-    - include: run_configs.yml
+    - include_tasks: run_configs.yml
       vars:
         runConfigsObj: '{{ componentObj.run_configs | default({}) }}'
       tags: run_configs
-    - include: run.yml
+    - include_tasks: run.yml
       vars:
         runObj: '{{ componentObj.run | default({}) }}'
       tags: run

--- a/roles/components/tasks/plugin.yml
+++ b/roles/components/tasks/plugin.yml
@@ -14,15 +14,15 @@
       vars:
         installObj: '{{ pluginObj.install | default({}) }}'
     - name: '{{ plugin_prefix }} configs'
-      include: configs.yml
+      include_tasks: configs.yml
       vars:
         configsObj: '{{ pluginObj.configs | default({}) }}'
     - name: '{{ plugin_prefix }} RunConfigs'
-      include: run_configs.yml
+      include_tasks: run_configs.yml
       vars:
         runConfigsObj: '{{ pluginObj.run_configs | default({}) }}'
     - name: '{{ plugin_prefix }} run'
-      include: run.yml
+      include_tasks: run.yml
       vars:
         runObj: '{{ pluginObj.run | default({}) }}'
   tags: [plugins]


### PR DESCRIPTION
Fix error:
```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```
Update all `include` to `include_tasks`